### PR TITLE
compile against Idris 1.3.0

### DIFF
--- a/src/IRTS/CodegenEs.hs
+++ b/src/IRTS/CodegenEs.hs
@@ -183,14 +183,14 @@ cgBody rt expr =
     expr -> cgBody' rt expr
 
 -- ordinary
-cgBody' rt (LV (Glob n)) = do
+cgBody' rt (LV n) = do
   st <- get
   case (lookupCtxtExact n (defs st)) of
     Just (LFun _ _ [a] d) -> do
       nm <- cgName n
       pure $ ([], addRT rt nm)
-    _ -> cgBody rt (LApp False (LV (Glob n)) []) -- recurry
-cgBody' rt (LApp _ (LV (Glob fn)) args) = do
+    _ -> cgBody rt (LApp False (LV n) []) -- recurry
+cgBody' rt (LApp _ (LV fn) args) = do
   let fname = jsName fn
   st <- get
   let (currFn, argN) = currentFnNameAndArgs st
@@ -211,7 +211,7 @@ cgBody' rt (LApp _ (LV (Glob fn)) args) = do
       app <- formApp fn (map (jsStmt2Expr . snd) z)
       pure $ (preDecs, addRT rt app)
 cgBody' rt (LForce (LLazyApp n args)) =
-  cgBody rt (LApp False (LV (Glob n)) args)
+  cgBody rt (LApp False (LV n) args)
 cgBody' rt (LLazyApp fn args) = do
   st <- get
   z <- mapM (cgBody GetExpBT) args

--- a/src/IRTS/CodegenEs/JsName.hs
+++ b/src/IRTS/CodegenEs/JsName.hs
@@ -38,7 +38,6 @@ showCGJS (SN s) = showCGJS' s
     showCGJS' (MethodN m) = "meth{" ++ showCGJS m ++ "}"
     showCGJS' (ParentN p c) = "par{" ++ showCGJS p ++ ";" ++ show c ++ "}"
     showCGJS' (CaseN fc c) = "case{" ++ showCGJS c ++ ";" ++ showFC' fc ++ "}"
-    showCGJS' (ElimN sn) = "elim{" ++ showCGJS sn ++ "}"
     showCGJS' (ImplementationCtorN n) = "ictor{" ++ showCGJS n ++ "}"
     showCGJS' (MetaN parent meta) =
       "meta{" ++ showCGJS parent ++ ";" ++ showCGJS meta ++ "}"

--- a/src/IRTS/CodegenEs/LangTransforms.hs
+++ b/src/IRTS/CodegenEs/LangTransforms.hs
@@ -26,8 +26,6 @@ import GHC.Generics (Generic)
 
 deriving instance Typeable (LAlt' LExp)
 
-deriving instance Data (LAlt' LExp)
-
 deriving instance Typeable FDesc
 
 deriving instance Data FDesc
@@ -135,7 +133,7 @@ used_functions alldefs (next_name:rest) =
 extract_globs :: LDefs -> LDecl -> [Name]
 extract_globs defs (LConstructor _ _ _) = []
 extract_globs defs (LFun _ _ _ e) =
-  let f (LV (Glob x)) = Just x
+  let f (LV x) = Just x
       f (LLazyApp x _) = Just x
       f _ = Nothing
   in [x | Just x <- map f $ universe e, memberCtx x defs]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,6 +4,7 @@ import Idris.AbsSyntax
 import Idris.Core.TT
 import Idris.ElabDecls
 import Idris.Main
+import Idris.Options
 
 import IRTS.CodegenEs
 import IRTS.Compiler


### PR DESCRIPTION
Should fix #1.

This builds and appears to produce the same (modulo line endings) output for everything in `tests/` that doesn't use `Js/Async`.